### PR TITLE
Tweaks

### DIFF
--- a/RPi/version.py
+++ b/RPi/version.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import print_function, absolute_import
+
+
 _memory_from_revision = [
     'Unkonwn',
     'Unkonwn',
@@ -245,7 +248,7 @@ _cpuinfo = _cpuinfo.replace("\t", "")
 _cpuinfo = _cpuinfo.split("\n")
 
 # Filter empty strings
-_cpuinfo = filter(len, _cpuinfo)
+_cpuinfo = list(filter(len, _cpuinfo))
 
 # Split into key/value dict
 _cpuinfo = dict(item.split(": ") for item in _cpuinfo)
@@ -321,14 +324,14 @@ info = {
         }
 
 if __name__ == "__main__":
-    print "---- Raspberry Pi Info ----"
-    print "Type:\t\t{}".format(type)
-    print "Model:\t\t{}".format(model)
-    print "Version:\t{}".format(version)
-    print "RAM:\t\t{}".format(memory)
-    print "CPU:\t\t{}".format(processor)
-    print "Manufacturer:\t{}".format(manufacturer)
-    print "PCB revision:\t{}".format(pcb_revision)
-    print "Revision:\t{}".format(_cpuinfo['Revision'])
-    print "Void waranty:\t{}".format(waranty)
-    print "---------------------------"
+    print("---- Raspberry Pi Info ----")
+    print("Type:\t\t{}".format(type))
+    print("Model:\t\t{}".format(model))
+    print("Version:\t{}".format(version))
+    print("RAM:\t\t{}".format(memory))
+    print("CPU:\t\t{}".format(processor))
+    print("Manufacturer:\t{}".format(manufacturer))
+    print("PCB revision:\t{}".format(pcb_revision))
+    print("Revision:\t{}".format(_cpuinfo['Revision']))
+    print("Void waranty:\t{}".format(waranty))
+    print("---------------------------")

--- a/RPi/version.py
+++ b/RPi/version.py
@@ -45,7 +45,7 @@ _type_from_revision = [
     'Model B',
     'Model B',
     'Model B+',
-    'Computer Module'
+    'Computer Module',
     'Model A+',
     'Model B+',
     'Computer Module',
@@ -120,7 +120,7 @@ _model_from_revision = [
     'B',
     'B',
     'B+',
-    'Computer Module'
+    'Computer Module',
     'A+',
     'B+',
     'Computer Module',

--- a/RPi/version.py
+++ b/RPi/version.py
@@ -323,7 +323,7 @@ info = {
         'version': version
         }
 
-if __name__ == "__main__":
+def main():
     print("---- Raspberry Pi Info ----")
     print("Type:\t\t{}".format(type))
     print("Model:\t\t{}".format(model))
@@ -335,3 +335,7 @@ if __name__ == "__main__":
     print("Revision:\t{}".format(_cpuinfo['Revision']))
     print("Void waranty:\t{}".format(waranty))
     print("---------------------------")
+
+
+if __name__ == '__main__':
+    main()

--- a/RPi/version.py
+++ b/RPi/version.py
@@ -24,7 +24,7 @@ _memory_from_revision = [
     256,
     512,
     512,
-    256
+    256,
 ]
 
 _type_from_revision = [
@@ -49,7 +49,7 @@ _type_from_revision = [
     'Model A+',
     'Model B+',
     'Computer Module',
-    'Model A+'
+    'Model A+',
 ]
 
 _manufacturer_from_revision = [
@@ -74,7 +74,7 @@ _manufacturer_from_revision = [
     'SONY',
     'EMBEST',
     'SONY',
-    'SONY'
+    'SONY',
 ]
 
 _pcb_from_revision = [
@@ -99,7 +99,7 @@ _pcb_from_revision = [
     1,
     1,
     1,
-    1
+    1,
 ]
 
 _model_from_revision = [
@@ -124,7 +124,7 @@ _model_from_revision = [
     'A+',
     'B+',
     'Computer Module',
-    'MA+'
+    'MA+',
 ]
 
 _version_from_revision = [
@@ -152,29 +152,11 @@ _version_from_revision = [
     1,
 ]
 
-_memory = [
-    256,
-    512,
-    1024,
-    2048,
-    4096
-]
+_memory = [256, 512, 1024, 2048, 4096]
 
-_manufacturer = [
-    'SONY',
-    'EGOMAN',
-    'EMBEST',
-    'SONY JAPAN',
-    'EMBEST',
-    'STADIUM'
-]
+_manufacturer = ['SONY', 'EGOMAN', 'EMBEST', 'SONY JAPAN', 'EMBEST', 'STADIUM']
 
-_processor = [
-    2835,
-    2836,
-    2837,
-    2711
-]
+_processor = [2835, 2836, 2837, 2711]
 
 _type = [
     'Model A',
@@ -194,7 +176,7 @@ _type = [
     'Model 3A+',
     'Internal',
     'Compute Module 3+',
-    'Model 4B'
+    'Model 4B',
 ]
 
 _model = [
@@ -215,28 +197,28 @@ _model = [
     '3A+',
     'Internal',
     '3+',
-    '4B'
+    '4B',
 ]
 
 _version = [
-     1,
-     1,
-     1,
-     1,
-     2,
-     'Unknown',
-     'Unknown',
-     'Unknown',
-     3,
-     'Zero',
-     3,
-     'Unknown',
-     'Zero W',
-     3,
-     3,
-     'Unknown',
-     3,
-     4
+    1,
+    1,
+    1,
+    1,
+    2,
+    'Unknown',
+    'Unknown',
+    'Unknown',
+    3,
+    'Zero',
+    3,
+    'Unknown',
+    'Zero W',
+    3,
+    3,
+    'Unknown',
+    3,
+    4,
 ]
 
 _cpuinfo = open('/proc/cpuinfo').read()
@@ -256,7 +238,7 @@ _cpuinfo = dict(item.split(": ") for item in _cpuinfo)
 # Convert revision string to integer
 _revision = int(_cpuinfo['Revision'], 16)
 
-#Bit field:
+# Bit field:
 """
 11000000000000000000000000 = 0x3000000 = WARANTY 
 00100000000000000000000000 = 0x0800000 = SCHEME
@@ -281,7 +263,7 @@ info = {}
 
 if _scheme:
 
-    waranty = int((_revision &  0x3000000) >> 24) > 0
+    waranty = int((_revision & 0x3000000) >> 24) > 0
 
     memory = _memory[(_revision & 0x700000) >> 20]
 
@@ -309,19 +291,20 @@ else:
     version = _version_from_revision[_revision]
 
     model = _model_from_revision[_revision]
-    
+
     pcb_revision = _pcb_from_revision[_revision]
 
 info = {
-        'memory': memory,
-        'manufacturer':  manufacturer,
-        'processor': processor,
-        'type': type,
-        'revision': _cpuinfo['Revision'],
-        'pcb_revision': pcb_revision,
-        'model': model,
-        'version': version
-        }
+    'memory': memory,
+    'manufacturer': manufacturer,
+    'processor': processor,
+    'type': type,
+    'revision': _cpuinfo['Revision'],
+    'pcb_revision': pcb_revision,
+    'model': model,
+    'version': version,
+}
+
 
 def main():
     print("---- Raspberry Pi Info ----")

--- a/setup.py
+++ b/setup.py
@@ -23,27 +23,29 @@ SOFTWARE.
 
 from setuptools import setup
 
-classifiers = ['Development Status :: 5 - Production/Stable',
-               'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: MIT License',
-               'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.6',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3',
-               'Topic :: Software Development',
-               'Topic :: System :: Hardware']
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Operating System :: POSIX :: Linux',
+    'License :: OSI Approved :: MIT License',
+    'Intended Audience :: Developers',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Topic :: Software Development',
+    'Topic :: System :: Hardware',
+]
 
-setup(name		= 'RPi.version',
-	version		= '1.2',
-	author		= 'Philip Howard',
-	author_email	= 'phil@pimoroni.com',
-	description	= 'Detailed information about Raspberry Pi version',
-	long_description= open('README.md').read() + open('CHANGELOG.md').read(),
-	license		= 'MIT',
-	keywords	= 'Raspberry Pi Version Information',
-	url		= 'http://www.pimoroni.com',
-	classifiers     = classifiers,
-	packages	= ['RPi'],
-	entry_points = {'console_scripts': ['rpi-version = RPi.version:main']},
+setup(
+    name='RPi.version',
+    version='1.2',
+    author='Philip Howard',
+    author_email='phil@pimoroni.com',
+    description='Detailed information about Raspberry Pi version',
+    long_description=open('README.md').read() + open('CHANGELOG.md').read(),
+    license='MIT',
+    keywords='Raspberry Pi Version Information',
+    url='http://www.pimoroni.com',
+    classifiers=classifiers,
+    packages=['RPi'],
+    entry_points={'console_scripts': ['rpi-version = RPi.version:main']},
 )
-

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: POSIX :: Linux',
@@ -43,6 +43,7 @@ setup(name		= 'RPi.version',
 	keywords	= 'Raspberry Pi Version Information',
 	url		= 'http://www.pimoroni.com',
 	classifiers     = classifiers,
-	packages	= ['RPi']
+	packages	= ['RPi'],
+	entry_points = {'console_scripts': ['rpi-version = RPi.version:main']},
 )
 


### PR DESCRIPTION
This contains a few minor tweaks for your code:

* update syntax to support Python 3
* add a setuptools entry point called `rpi-version`
* add two missing commas in lists that _look_ like accidental omissions
* run the [Black](https://black.readthedocs.io/en/stable/) code formatter on the sources (which was how I noticed the former)